### PR TITLE
Correct the "ts-ignore" anomaly

### DIFF
--- a/src/components/champion.tsx
+++ b/src/components/champion.tsx
@@ -1,14 +1,11 @@
 import * as React from 'react';
-// @ts-ignore
-import { Avatar, Button, Grid, List, ListItem, ListItemAvatar, ListItemText} from "@material-ui/core";
-import {FC, useEffect, useState} from "react";
-// @ts-ignore
-import {mdiSword, mdiFire, mdiPlusOutline, mdiFlash, mdiShield, mdiAxe, mdiCircleSlice8, mdiRunFast} from '@mdi/js';
-// @ts-ignore
-import Icon from '@mdi/react'
-// @ts-ignore
+import { FC, useEffect, useState } from "react";
+import { Avatar, Button, Grid, List, ListItem, ListItemAvatar, ListItemText } from "@material-ui/core";
 import { makeStyles } from '@material-ui/core/styles';
-import { Champion, Data } from 'model';
+import { mdiSword, mdiFire, mdiPlusOutline, mdiFlash, mdiShield, mdiAxe, mdiCircleSlice8, mdiRunFast } from '@mdi/js';
+import { Icon }  from '@mdi/react'
+import { Data, Champion } from "./model";
+
 
 type ChampionProps = Readonly<{
     champion:Champion

--- a/src/components/model.ts
+++ b/src/components/model.ts
@@ -7,4 +7,3 @@ export interface Champion {
     title:string,
     blurb:string
 }
-

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-
-
 import { Champions } from "./components/champion";
-// @ts-ignore
-import {Grid} from "@material-ui/core";
+import { Grid } from "@material-ui/core";
 
 
 class Hello extends React.Component {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
     "jsx": "react",
     "allowJs": true,
     "allowSyntheticDefaultImports" : true,
-    "esModuleInterop" : true
-  }
+    "esModuleInterop" : true,
+    "moduleResolution": "Node"
+  },
+  "include": ["src"],
+  "exclude": [
+    "node_modules/**",
+  ]
 }


### PR DESCRIPTION
**Motivation**

- To remove the need to add "ts-ignore" before any import from Node modules.

**Modification**

- Added the line "moduleResolution": "Node" to the _tsconfig.json_ file to solve the problem
- Removed all "ts-ignore" lines

**Remarks**

- Always check _tsconfig.json_ in case of TypeScript-linked errors.