### PR TITLE
(SC-7) Tweaked webpack config to display the page /champion correctly

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
         contentBase: path.join(__dirname, ''),
         compress: true,
         port: 3000,
+        historyApiFallback: true,
     },
 
     resolve: {
@@ -17,6 +18,7 @@ module.exports = {
     output: {
         filename: 'bundle.js',
         path: path.resolve(__dirname, 'dist'),
+        publicPath: '/'
     },
 
     module: {


### PR DESCRIPTION
**Motivation**
 
- To fix a bug that prevents from reaching /champion directly.
 
**Modification**
 
- Added a modification to the Webpack config to solve the problem.
 
**Remarks**
 
- The bug has now been solved and /champion can be reached correctly. Link to the solution : https://ui.dev/react-router-cannot-get-url-refresh/
