### PR TITLE
(SC-12) Add the champion's avatar to the search bar

### DIFF
--- a/src/app/components/champion/ChampionView.tsx
+++ b/src/app/components/champion/ChampionView.tsx
@@ -30,6 +30,11 @@ export const ChampionView: FC<ChampionProps> = ({champion, callback, championsLi
         },
         statsBox: {
             border: 'solid'
+        },
+        avatarSearch: {
+            height: '22%',
+            width: '22%',
+            marginRight:'5%'
         }
     });
 
@@ -40,12 +45,18 @@ export const ChampionView: FC<ChampionProps> = ({champion, callback, championsLi
             <Autocomplete
                 id="combo-box-demo"
                 options={championsList}
-                getOptionLabel={(option) => option.name}
+                getOptionLabel={(option) =>  option.name}
                 style={{width: '60%'}}
                 onChange={callback}
+                renderOption={(option) => (
+                    <React.Fragment>
+                        <Avatar className={classes.avatarSearch} src={"http://ddragon.leagueoflegends.com/cdn/11.6.1/img/champion/"+option.name+".png"}/>
+                        {option.name}
+                    </React.Fragment>
+                )}
                 getOptionSelected={(option, value) => value.name === option.name}
                 renderInput={
-                    (params) => <TextField {...params}  label="Champion" variant="outlined"/>
+                    (params) => <TextField {...params} label="Champion" variant="outlined"/>
                 }
             />
             <ListItem key='IDCard'>


### PR DESCRIPTION
**Motivation**
 
- To show the avatar of the champions in the autocomplete list, for visual clarity.
 
**Modification**

 - Modified the Autocomplete component to display the avatar as well.
 
**Remarks**

- The Avatar tag can be replaced with an img tag if prefered, but Avatar makes it simpler to maintain IMO.
