### PR TITLE
(SC-17) Add cooldowns to the tooltip + spinner to ChampionSelector

### DIFF
--- a/src/app/components/champion/ChampionSelector.tsx
+++ b/src/app/components/champion/ChampionSelector.tsx
@@ -5,7 +5,7 @@ import {ChampionView} from "./ChampionView";
 import {getUrlChampion, getUrlChampionAvatar, getUrlChampionList} from "../../config/config";
 import {useFetchAPI} from "../../api/reducer";
 import {Autocomplete} from "@material-ui/lab";
-import {Avatar, List, TextField} from "@material-ui/core";
+import {Avatar, CircularProgress, List, TextField} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import {extractChampion, extractChampionList} from "../../misc/utils";
 
@@ -19,6 +19,11 @@ export const ChampionSelector = () => {
             height: '12%',
             width: '12%',
             marginRight: '5%'
+        },
+        loaderBox: {
+            width: '100%',
+            textAlign: 'center',
+            marginTop: '30%'
         }
     }));
 
@@ -47,7 +52,10 @@ export const ChampionSelector = () => {
                     (params) => <TextField {...params} label="Champion" variant="outlined"/>
                 }
             />
-            {championState.isLoading || !championState.data ? <h1>Loading your champion...</h1> :
+            {championState.isLoading || !championState.data ?
+                <div className={classes.loaderBox}>
+                    <CircularProgress color="secondary" size={80}/>
+                </div> :
                 <ChampionView champion={championState.data as Champion}/>}
         </List>
     )

--- a/src/app/components/champion/ChampionSelector.tsx
+++ b/src/app/components/champion/ChampionSelector.tsx
@@ -5,9 +5,10 @@ import {ChampionView} from "./ChampionView";
 import {getUrlChampion, getUrlChampionAvatar, getUrlChampionList} from "../../config/config";
 import {useFetchAPI} from "../../api/reducer";
 import {Autocomplete} from "@material-ui/lab";
-import {Avatar, CircularProgress, List, TextField} from "@material-ui/core";
+import {Avatar, List, TextField} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 import {extractChampion, extractChampionList} from "../../misc/utils";
+import {Spinner} from "../commons/Spinner";
 
 export const ChampionSelector = () => {
     const [championId, setChampionId] = useState("Aatrox")
@@ -20,11 +21,7 @@ export const ChampionSelector = () => {
             width: '12%',
             marginRight: '5%'
         },
-        loaderBox: {
-            width: '100%',
-            textAlign: 'center',
-            marginTop: '30%'
-        }
+
     }));
 
     const classes = useStyles();
@@ -52,10 +49,7 @@ export const ChampionSelector = () => {
                     (params) => <TextField {...params} label="Champion" variant="outlined"/>
                 }
             />
-            {championState.isLoading || !championState.data ?
-                <div className={classes.loaderBox}>
-                    <CircularProgress color="secondary" size={80}/>
-                </div> :
+            {championState.isLoading || !championState.data ? <Spinner /> :
                 <ChampionView champion={championState.data as Champion}/>}
         </List>
     )

--- a/src/app/components/champion/ChampionView.tsx
+++ b/src/app/components/champion/ChampionView.tsx
@@ -18,7 +18,7 @@ import {mdiAxe, mdiCircleSlice8, mdiFlash, mdiPlusOutline, mdiRunFast, mdiShield
 import {Icon} from '@mdi/react'
 import {Champion} from "../model/models";
 import {getUrlChampionAvatar, getUrlPassive, getUrlSpell} from "../../config/config";
-import {cleanDescription} from "../../misc/utils";
+import {cleanCooldown, cleanDescription} from "../../misc/utils";
 
 type ChampionProps = Readonly<{
     champion: Champion
@@ -81,7 +81,7 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
             <ListItem key='Abilities'>
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.passive.name}</h2><br/>
+                        <h2 color="inherit">{champion.passive.name}</h2>
                         {cleanDescription(champion.passive.description)}
                     </React.Fragment>}>
                     <Avatar className={classes.abilityIcon} alt={champion.name} variant='square'
@@ -90,7 +90,8 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[0].name}</h2><br/>
+                        <h2 color="inherit">{champion.spells[0].name}</h2>
+                        <h3>{'Cooldown : ' + cleanCooldown(champion.spells[0].cooldown)}</h3>
                         {cleanDescription(champion.spells[0].description)}
                     </React.Fragment>}>
                     <Avatar className={classes.abilityIcon} alt={champion.name} variant='square'
@@ -99,7 +100,8 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[1].name}</h2><br/>
+                        <h2 color="inherit">{champion.spells[1].name}</h2>
+                        <h3>{'Cooldown : ' + cleanCooldown(champion.spells[1].cooldown)}</h3>
                         {cleanDescription(champion.spells[1].description)}
                     </React.Fragment>}>
                     <Avatar className={classes.abilityIcon} alt={champion.name} variant='square'
@@ -108,7 +110,8 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[2].name}</h2><br/>
+                        <h2 color="inherit">{champion.spells[2].name}</h2>
+                        <h3>{'Cooldown : ' + cleanCooldown(champion.spells[2].cooldown)}</h3>
                         {cleanDescription(champion.spells[2].description)}
                     </React.Fragment>}>
                     <Avatar className={classes.abilityIcon} alt={champion.name} variant='square'
@@ -117,7 +120,8 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[3].name}</h2><br/>
+                        <h2 color="inherit">{champion.spells[3].name}</h2>
+                        <h3>{'Cooldown : ' + cleanCooldown(champion.spells[3].cooldown)}</h3>
                         {cleanDescription(champion.spells[3].description)}
                     </React.Fragment>}>
                     <Avatar className={classes.abilityIcon} alt={champion.name} variant='square'

--- a/src/app/components/commons/Spinner.tsx
+++ b/src/app/components/commons/Spinner.tsx
@@ -1,0 +1,21 @@
+import {CircularProgress} from "@material-ui/core";
+import React from "react";
+import {makeStyles} from "@material-ui/core/styles";
+
+export const Spinner = () => {
+    const useStyles = makeStyles(() => ({
+    loaderBox: {
+        width: '100%',
+            textAlign: 'center',
+            marginTop: '30%'
+        }
+    }))
+
+    const classes = useStyles();
+
+    return (
+        <div className={classes.loaderBox}>
+            <CircularProgress color="secondary" size={80}/>
+        </div>
+    )
+}

--- a/src/app/components/model/models.ts
+++ b/src/app/components/model/models.ts
@@ -27,13 +27,14 @@ export interface Champion {
             full: string
         }
     }
-    spells: Passive[]
+    spells: Spell[]
 }
 
-interface Passive {
+interface Spell {
     name: string,
     description: string,
     image: {
         full: string
     }
+    cooldown:Number[]
 }

--- a/src/app/misc/utils.ts
+++ b/src/app/misc/utils.ts
@@ -8,6 +8,7 @@ export function cleanDescription(description: string) {
 
 export function cleanCooldown(cooldowns:Number[]) {
     //This displays the cooldowns of an ability and replaces all the , with /
+    //Example : changes "4,5,8,3" to "4/5/8/3"
     return cooldowns.toString().replace(/[ ]*,[ ]*|[ ]+/g, '/')
 }
 

--- a/src/app/misc/utils.ts
+++ b/src/app/misc/utils.ts
@@ -6,6 +6,11 @@ export function cleanDescription(description: string) {
     return description.replace(/<[^>]*>/g, '')
 }
 
+export function cleanCooldown(cooldowns:Number[]) {
+    //This displays the cooldowns of an ability and replaces all the , with /
+    return cooldowns.toString().replace(/[ ]*,[ ]*|[ ]+/g, '/')
+}
+
 export function extractChampionList(data: Data) {
     return Object.values(data.data) as Champion[]
 }

--- a/src/app/theme/GlobalStyleProvider.tsx
+++ b/src/app/theme/GlobalStyleProvider.tsx
@@ -15,6 +15,10 @@ const useStyles = makeStyles<Theme>((theme) => ({
         },
         h2:  {
             fontSize: '1.25em'
+        },
+        h3: {
+            fontSize: '1em',
+            color: theme.palette.secondary.light
         }
     }
 }))


### PR DESCRIPTION
**Motivation**
 
- To add the abilities' cooldowns to the tooltip
- To add a loading spinner while waiting for API response
 
**Modification**
 
- Added the cooldowns to the Tooltip along with the changes to the model.ts
- Added a CircularProgress loader instead of the h2.
 
**Remarks**
 
- Progression in the loader could be added, but doesn't seem to add enough in my opinion.
