### PR TITLE
(SC-19) Add a "Matchup" viewer + "Matchup" poster

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -15,10 +15,8 @@ export const App = () => {
             <GlobalStyleProvider>
                 <CssBaseline/>
                 <Header/>
-                <Grid container justify='center'>
-                    <Grid item md={4}>
-                        <Routes/>
-                    </Grid>
+                <Grid container spacing={3} justify='center'>
+                    <Routes/>
                 </Grid>
             </GlobalStyleProvider>
         </ThemeProvider>

--- a/src/app/components/champion/ChampionSelector.tsx
+++ b/src/app/components/champion/ChampionSelector.tsx
@@ -18,7 +18,6 @@ export const ChampionSelector = () => {
     const championListState = useFetchAPI<Data, Champion[]>([], () => axios.get(getUrlChampionList()), [], extractChampionList)
     const championState = useFetchAPI<Data, Champion>(undefined, () => axios.get(getUrlChampion(championId)), [championId], extractChampion)
 
-
     const useStyles = makeStyles(() => ({
         avatarSearch: {
             height: '12%',
@@ -51,7 +50,7 @@ export const ChampionSelector = () => {
                     )}
                     getOptionSelected={(option, value) => value.name === option.name}
                     renderInput={
-                        (params) => <TextField {...params} label="Champion" variant="outlined" />
+                        (params) => <TextField {...params} label="Champion" variant="outlined"/>
                     }
                 />
                 {championState.isLoading || !championState.data ? <Spinner/> :
@@ -59,7 +58,8 @@ export const ChampionSelector = () => {
             </Grid>
             <Grid item md={4}>
                 {championListState.isLoading || (championListState.data as Champion[]).length <= 0 ? <Spinner/> :
-                    opponents.map((championName) => <OpponentView opponent={getChampionByName(championListState.data as Champion[], championName)} />)}
+                    opponents.map((championName) => <OpponentView
+                        opponent={getChampionByName(championListState.data as Champion[], championName)}/>)}
             </Grid>
         </React.Fragment>
     )

--- a/src/app/components/champion/ChampionSelector.tsx
+++ b/src/app/components/champion/ChampionSelector.tsx
@@ -36,10 +36,10 @@ export const ChampionSelector = () => {
                 <Autocomplete
                     id="champion-box-complete"
                     options={championListState.data as Champion[]}
-                    getOptionLabel={(option) => option.id}
-                    onInputChange={(event, newInputValue) => {
-                        if (newInputValue !== '') {
-                            setChampionId(newInputValue)
+                    getOptionLabel={(option) => option.name}
+                    onChange={(event, newValue) => {
+                        if (newValue) {
+                            setChampionId((newValue as Champion).id as string)
                         }
                     }}
                     renderOption={(option) => (

--- a/src/app/components/champion/ChampionView.tsx
+++ b/src/app/components/champion/ChampionView.tsx
@@ -68,7 +68,7 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
             <ListItem key='Abilities'>
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.passive.name}</h2>
+                        <h2 color="inherit">Passive - {champion.passive.name}</h2>
                         {cleanDescription(champion.passive.description)}
                     </React.Fragment>}>
                     <Avatar className={classes.abilityIcon} alt={champion.name} variant='square'
@@ -77,7 +77,7 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[0].name}</h2>
+                        <h2 color="inherit">Q - {champion.spells[0].name}</h2>
                         <h3>{'Cooldown : ' + cleanCooldown(champion.spells[0].cooldown)}</h3>
                         {cleanDescription(champion.spells[0].description)}
                     </React.Fragment>}>
@@ -87,7 +87,7 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[1].name}</h2>
+                        <h2 color="inherit">W - {champion.spells[1].name}</h2>
                         <h3>{'Cooldown : ' + cleanCooldown(champion.spells[1].cooldown)}</h3>
                         {cleanDescription(champion.spells[1].description)}
                     </React.Fragment>}>
@@ -97,7 +97,7 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[2].name}</h2>
+                        <h2 color="inherit">E - {champion.spells[2].name}</h2>
                         <h3>{'Cooldown : ' + cleanCooldown(champion.spells[2].cooldown)}</h3>
                         {cleanDescription(champion.spells[2].description)}
                     </React.Fragment>}>
@@ -107,7 +107,7 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
 
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
-                        <h2 color="inherit">{champion.spells[3].name}</h2>
+                        <h2 color="inherit">R - {champion.spells[3].name}</h2>
                         <h3>{'Cooldown : ' + cleanCooldown(champion.spells[3].cooldown)}</h3>
                         {cleanDescription(champion.spells[3].description)}
                     </React.Fragment>}>

--- a/src/app/components/champion/ChampionView.tsx
+++ b/src/app/components/champion/ChampionView.tsx
@@ -1,16 +1,6 @@
 import * as React from 'react';
 import {FC, useState} from 'react';
-import {
-    Avatar,
-    Box,
-    Fade,
-    Grid, List,
-    ListItem,
-    Slider,
-    Theme,
-    Tooltip,
-    withStyles,
-} from "@material-ui/core";
+import {Avatar, Box, Fade, Grid, List, ListItem, Slider, Theme, Tooltip, withStyles,} from "@material-ui/core";
 import {makeStyles} from '@material-ui/core/styles';
 import {mdiAxe, mdiCircleSlice8, mdiFlash, mdiPlusOutline, mdiRunFast, mdiShield, mdiSword, mdiWater} from '@mdi/js';
 import {Icon} from '@mdi/react'
@@ -136,25 +126,32 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
                 <ListItem key='Stats'>
                     <Grid container spacing={2}>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiPlusOutline}/>{computeStat(champion.stats.hp, champion.stats.hpperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiPlusOutline}/>{computeStat(champion.stats.hp, champion.stats.hpperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiWater}/>{computeStat(champion.stats.mp, champion.stats.mpperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiWater}/>{computeStat(champion.stats.mp, champion.stats.mpperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiAxe}/>{computeStat(champion.stats.attackspeed, champion.stats.attackspeedperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiAxe}/>{computeStat(champion.stats.attackspeed, champion.stats.attackspeedperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiShield}/>{computeStat(champion.stats.armor, champion.stats.armorperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiShield}/>{computeStat(champion.stats.armor, champion.stats.armorperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiSword}/>{computeStat(champion.stats.attackdamage, champion.stats.attackdamageperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiSword}/>{computeStat(champion.stats.attackdamage, champion.stats.attackdamageperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiFlash}/>{computeStat(champion.stats.crit, champion.stats.critperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiFlash}/>{computeStat(champion.stats.crit, champion.stats.critperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
-                            <Icon className={classes.icon} path={mdiCircleSlice8}/>{computeStat(champion.stats.spellblock, champion.stats.spellblockperlevel, championLevel)}
+                            <Icon className={classes.icon}
+                                  path={mdiCircleSlice8}/>{computeStat(champion.stats.spellblock, champion.stats.spellblockperlevel, championLevel)}
                         </Grid>
                         <Grid item xs={4}>
                             <Icon className={classes.icon} path={mdiRunFast}/>{champion.stats.movespeed}

--- a/src/app/components/champion/ChampionView.tsx
+++ b/src/app/components/champion/ChampionView.tsx
@@ -4,10 +4,8 @@ import {
     Avatar,
     Box,
     Fade,
-    Grid,
+    Grid, List,
     ListItem,
-    ListItemAvatar,
-    ListItemText,
     Slider,
     Theme,
     Tooltip,
@@ -17,8 +15,9 @@ import {makeStyles} from '@material-ui/core/styles';
 import {mdiAxe, mdiCircleSlice8, mdiFlash, mdiPlusOutline, mdiRunFast, mdiShield, mdiSword, mdiWater} from '@mdi/js';
 import {Icon} from '@mdi/react'
 import {Champion} from "../model/models";
-import {getUrlChampionAvatar, getUrlPassive, getUrlSpell} from "../../config/config";
+import {getUrlPassive, getUrlSpell} from "../../config/config";
 import {cleanCooldown, cleanDescription, computeStat} from "../../misc/utils";
+import {IDCard} from "../commons/IDCard";
 
 type ChampionProps = Readonly<{
     champion: Champion
@@ -64,22 +63,8 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
     }))(Tooltip)
 
     return (
-        <React.Fragment>
-            <ListItem key='IDCard'>
-                <ListItemAvatar>
-                    <Avatar className={classes.avatarDisplay} alt={champion.name} variant='square'
-                            src={getUrlChampionAvatar(champion.image.full)}/>
-                </ListItemAvatar>
-                <ListItemText
-                    classes={{
-                        primary: classes.itemTextSizePrimary,
-                        secondary: classes.itemTextSizeSecondary
-                    }}
-                    primary={champion.name}
-                    secondary={champion.title}
-                />
-            </ListItem>
-
+        <List>
+            <IDCard champion={champion}/>
             <ListItem key='Abilities'>
                 <AbilityTooltip TransitionComponent={Fade} TransitionProps={{timeout: 600}} arrow title={
                     <React.Fragment>
@@ -177,6 +162,6 @@ export const ChampionView: FC<ChampionProps> = ({champion}) => {
                     </Grid>
                 </ListItem>
             </Box>
-        </React.Fragment>
+        </List>
     )
 }

--- a/src/app/components/commons/IDCard.tsx
+++ b/src/app/components/commons/IDCard.tsx
@@ -1,9 +1,9 @@
+import * as React from "react";
 import {FC} from "react";
 import {Champion} from "../model/models";
 import {makeStyles} from "@material-ui/core/styles";
 import {Avatar, ListItem, ListItemAvatar, ListItemText} from "@material-ui/core";
 import {getUrlChampionAvatar} from "../../config/config";
-import * as React from "react";
 
 type IDCardProps = Readonly<{
     champion: Champion

--- a/src/app/components/commons/IDCard.tsx
+++ b/src/app/components/commons/IDCard.tsx
@@ -1,0 +1,44 @@
+import {FC} from "react";
+import {Champion} from "../model/models";
+import {makeStyles} from "@material-ui/core/styles";
+import {Avatar, ListItem, ListItemAvatar, ListItemText} from "@material-ui/core";
+import {getUrlChampionAvatar} from "../../config/config";
+import * as React from "react";
+
+type IDCardProps = Readonly<{
+    champion: Champion
+}>
+
+export const IDCard: FC<IDCardProps> = ({champion}) => {
+    const useStyles = makeStyles(() => ({
+        avatarDisplay: {
+            height: '70%',
+            width: '70%',
+        },
+        itemTextSizePrimary: {
+            fontSize: '2em'
+        },
+        itemTextSizeSecondary: {
+            fontSize: '1.3em'
+        }
+    }));
+
+    const classes = useStyles();
+
+    return (
+        <ListItem key='IDCard'>
+            <ListItemAvatar>
+                <Avatar className={classes.avatarDisplay} alt={champion.name} variant='square'
+                        src={getUrlChampionAvatar(champion.image.full)}/>
+            </ListItemAvatar>
+            <ListItemText
+                classes={{
+                    primary: classes.itemTextSizePrimary,
+                    secondary: classes.itemTextSizeSecondary
+                }}
+                primary={champion.name}
+                secondary={champion.title}
+            />
+        </ListItem>
+    )
+}

--- a/src/app/components/opponent/OpponentView.tsx
+++ b/src/app/components/opponent/OpponentView.tsx
@@ -2,7 +2,7 @@ import {Champion} from "../model/models";
 import * as React from "react";
 import {FC} from "react";
 import {IDCard} from "../commons/IDCard";
-import {Accordion, AccordionDetails, AccordionSummary, Button, Theme} from "@material-ui/core";
+import {Accordion, AccordionDetails, AccordionSummary, Button, TextField, Theme} from "@material-ui/core";
 import {makeStyles} from "@material-ui/core/styles";
 
 type OpponentProps = Readonly<{
@@ -12,7 +12,8 @@ type OpponentProps = Readonly<{
 export const OpponentView: FC<OpponentProps> = ({opponent}) => {
     const useStyles = makeStyles((theme: Theme) => ({
         accordion: {
-            backgroundColor: theme.palette.primary.main
+            backgroundColor: theme.palette.primary.main,
+            padding:"1%"
         },
         severityLevel: {
             backgroundColor: theme.palette.error.main,
@@ -23,13 +24,12 @@ export const OpponentView: FC<OpponentProps> = ({opponent}) => {
             alignItems: "center",
         },
         tipButtonsBox: {
-            display:"flex",
-            justifyContent:"flex-end"
+            display: "flex",
+            justifyContent: "flex-end"
         },
         tipButtons: {
-            margin:"3%"
-        },
-
+            margin: "3%"
+        }
     }));
 
     const classes = useStyles();
@@ -57,6 +57,20 @@ export const OpponentView: FC<OpponentProps> = ({opponent}) => {
                             <Button className={classes.tipButtons} variant="contained" color="secondary">
                                 See Another Tip
                             </Button>
+                        </div>
+                        <TextField
+                            label="Your tip"
+                            placeholder="Example : Take TP, save your E..."
+                            helperText="Write your tip for this matchup here, and we will add it to the list !"
+                            fullWidth
+                            multiline
+                            rows = "3"
+                            color = "secondary"
+                            InputLabelProps={{
+                                shrink: true,
+                            }}
+                        />
+                        <div className={classes.tipButtonsBox}>
                             <Button className={classes.tipButtons} variant="contained" color="secondary">
                                 Post a Tip
                             </Button>

--- a/src/app/components/opponent/OpponentView.tsx
+++ b/src/app/components/opponent/OpponentView.tsx
@@ -1,0 +1,69 @@
+import {Champion} from "../model/models";
+import * as React from "react";
+import {FC} from "react";
+import {IDCard} from "../commons/IDCard";
+import {Accordion, AccordionDetails, AccordionSummary, Button, Theme} from "@material-ui/core";
+import {makeStyles} from "@material-ui/core/styles";
+
+type OpponentProps = Readonly<{
+    opponent: Champion
+}>
+
+export const OpponentView: FC<OpponentProps> = ({opponent}) => {
+    const useStyles = makeStyles((theme: Theme) => ({
+        accordion: {
+            backgroundColor: theme.palette.primary.main
+        },
+        severityLevel: {
+            backgroundColor: theme.palette.error.main,
+            height: "30%"
+        },
+        severityBox: {
+            display: "flex",
+            alignItems: "center",
+        },
+        tipButtonsBox: {
+            display:"flex",
+            justifyContent:"flex-end"
+        },
+        tipButtons: {
+            margin:"3%"
+        },
+
+    }));
+
+    const classes = useStyles();
+
+    return (
+        <React.Fragment>
+            <Accordion className={classes.accordion}>
+                <AccordionSummary>
+                    <IDCard champion={opponent}/>
+                    <div className={classes.severityBox}>
+                        <Button
+                            variant="contained"
+                            className={classes.severityLevel}
+                            onClick={(event) => event.stopPropagation()}
+                            onFocus={(event) => event.stopPropagation()}
+                        >
+                            Extreme
+                        </Button>
+                    </div>
+                </AccordionSummary>
+                <AccordionDetails>
+                    <div>
+                        {opponent.blurb}
+                        <div className={classes.tipButtonsBox}>
+                            <Button className={classes.tipButtons} variant="contained" color="secondary">
+                                See Another Tip
+                            </Button>
+                            <Button className={classes.tipButtons} variant="contained" color="secondary">
+                                Post a Tip
+                            </Button>
+                        </div>
+                    </div>
+                </AccordionDetails>
+            </Accordion>
+        </React.Fragment>
+    )
+}

--- a/src/app/components/opponent/OpponentView.tsx
+++ b/src/app/components/opponent/OpponentView.tsx
@@ -13,7 +13,7 @@ export const OpponentView: FC<OpponentProps> = ({opponent}) => {
     const useStyles = makeStyles((theme: Theme) => ({
         accordion: {
             backgroundColor: theme.palette.primary.main,
-            padding:"1%"
+            padding: "1%"
         },
         severityLevel: {
             backgroundColor: theme.palette.error.main,
@@ -35,49 +35,47 @@ export const OpponentView: FC<OpponentProps> = ({opponent}) => {
     const classes = useStyles();
 
     return (
-        <React.Fragment>
-            <Accordion className={classes.accordion}>
-                <AccordionSummary>
-                    <IDCard champion={opponent}/>
-                    <div className={classes.severityBox}>
-                        <Button
-                            variant="contained"
-                            className={classes.severityLevel}
-                            onClick={(event) => event.stopPropagation()}
-                            onFocus={(event) => event.stopPropagation()}
-                        >
-                            Extreme
+        <Accordion className={classes.accordion}>
+            <AccordionSummary>
+                <IDCard champion={opponent}/>
+                <div className={classes.severityBox}>
+                    <Button
+                        variant="contained"
+                        className={classes.severityLevel}
+                        onClick={(event) => event.stopPropagation()}
+                        onFocus={(event) => event.stopPropagation()}
+                    >
+                        Extreme
+                    </Button>
+                </div>
+            </AccordionSummary>
+            <AccordionDetails>
+                <div>
+                    {opponent.blurb}
+                    <div className={classes.tipButtonsBox}>
+                        <Button className={classes.tipButtons} variant="contained" color="secondary">
+                            See Another Tip
                         </Button>
                     </div>
-                </AccordionSummary>
-                <AccordionDetails>
-                    <div>
-                        {opponent.blurb}
-                        <div className={classes.tipButtonsBox}>
-                            <Button className={classes.tipButtons} variant="contained" color="secondary">
-                                See Another Tip
-                            </Button>
-                        </div>
-                        <TextField
-                            label="Your tip"
-                            placeholder="Example : Take TP, save your E..."
-                            helperText="Write your tip for this matchup here, and we will add it to the list !"
-                            fullWidth
-                            multiline
-                            rows = "3"
-                            color = "secondary"
-                            InputLabelProps={{
-                                shrink: true,
-                            }}
-                        />
-                        <div className={classes.tipButtonsBox}>
-                            <Button className={classes.tipButtons} variant="contained" color="secondary">
-                                Post a Tip
-                            </Button>
-                        </div>
+                    <TextField
+                        label="Your tip"
+                        placeholder="Example : Take TP, save your E..."
+                        helperText="Write your tip for this matchup here, and we will add it to the list !"
+                        fullWidth
+                        multiline
+                        rows="3"
+                        color="secondary"
+                        InputLabelProps={{
+                            shrink: true,
+                        }}
+                    />
+                    <div className={classes.tipButtonsBox}>
+                        <Button className={classes.tipButtons} variant="contained" color="secondary">
+                            Post a Tip
+                        </Button>
                     </div>
-                </AccordionDetails>
-            </Accordion>
-        </React.Fragment>
+                </div>
+            </AccordionDetails>
+        </Accordion>
     )
 }

--- a/src/app/misc/utils.ts
+++ b/src/app/misc/utils.ts
@@ -27,11 +27,7 @@ export function computeStat(base:number, growth:number, level:number) {
 }
 
 export function getChampionByName(champions:Champion[], name:string) {
-    let championRet
-    champions.forEach(element => {
-        if (element.name == name) {
-            championRet = element
-        }
-    })
-    return championRet
+    //Takes a champion's name and a list of champions and returns the champion with the same "name" value from the list.
+    const result = champions.filter((element) => element.name === name)
+    return result[0]
 }

--- a/src/app/misc/utils.ts
+++ b/src/app/misc/utils.ts
@@ -6,7 +6,7 @@ export function cleanDescription(description: string) {
     return description.replace(/<[^>]*>/g, '')
 }
 
-export function cleanCooldown(cooldowns:Number[]) {
+export function cleanCooldown(cooldowns: Number[]) {
     //This displays the cooldowns of an ability and replaces all the , with /
     //Example : changes "4,5,8,3" to "4/5/8/3"
     return cooldowns.toString().replace(/[ ]*,[ ]*|[ ]+/g, '/')
@@ -20,13 +20,13 @@ export function extractChampion(data: Data) {
     return Object.values(data.data)[0] as Champion
 }
 
-export function computeStat(base:number, growth:number, level:number) {
+export function computeStat(base: number, growth: number, level: number) {
     //Takes the base stat, growth value and level of a champion and returns the calculated stat at this level
     const growthComputed = growth * (0.65 + 0.035 * level)
-    return Math.round(base + growthComputed*(level-1) * (0.7025 + 0.0175 * (level-1)))
+    return Math.round(base + growthComputed * (level - 1) * (0.7025 + 0.0175 * (level - 1)))
 }
 
-export function getChampionByName(champions:Champion[], name:string) {
+export function getChampionByName(champions: Champion[], name: string) {
     //Takes a champion's name and a list of champions and returns the champion with the same "name" value from the list.
     const result = champions.filter((element) => element.name === name)
     return result[0]

--- a/src/app/misc/utils.ts
+++ b/src/app/misc/utils.ts
@@ -25,3 +25,13 @@ export function computeStat(base:number, growth:number, level:number) {
     const growthComputed = growth * (0.65 + 0.035 * level)
     return Math.round(base + growthComputed*(level-1) * (0.7025 + 0.0175 * (level-1)))
 }
+
+export function getChampionByName(champions:Champion[], name:string) {
+    let championRet
+    champions.forEach(element => {
+        if (element.name == name) {
+            championRet = element
+        }
+    })
+    return championRet
+}

--- a/src/app/theme/GlobalStyleProvider.tsx
+++ b/src/app/theme/GlobalStyleProvider.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
             background: '#070720',
             overflowX: 'hidden'
         },
-        h2:  {
+        h2: {
             fontSize: '1.25em'
         },
         h3: {

--- a/src/app/theme/GlobalStyleProvider.tsx
+++ b/src/app/theme/GlobalStyleProvider.tsx
@@ -11,7 +11,8 @@ const useStyles = makeStyles<Theme>((theme) => ({
             fontFamily: 'Rubik',
             color: theme.palette.common.white,
             height: '100%',
-            background: '#070720'
+            background: '#070720',
+            overflowX: 'hidden'
         },
         h2:  {
             fontSize: '1.25em'

--- a/src/app/theme/Theme.ts
+++ b/src/app/theme/Theme.ts
@@ -22,4 +22,5 @@ export const theme = createMuiTheme({
             main: '#3273FA',
         },
     },
+
 });

--- a/src/app/theme/Theme.ts
+++ b/src/app/theme/Theme.ts
@@ -11,7 +11,7 @@ export const theme = createMuiTheme({
 
     palette: {
         type: 'dark',
-        common:  {
+        common: {
             black: '#434449',
             white: '#EAEBF0'
         },
@@ -22,5 +22,4 @@ export const theme = createMuiTheme({
             main: '#3273FA',
         },
     },
-
 });


### PR DESCRIPTION
**Motivation**
 
- To add a static Matchup viewer with the list of matchups
- To add a Tip area for matchups and an area to post tips
 
**Modification**
 
- Added the opponent matchup area to OpponentView
- Moved the ID card to it's own component tu use it in the Opponent area
 
**Remarks**
 
- The Matchup area wil be enhanced and functional once Firebase is set up
